### PR TITLE
build EEG.BIDS on import and add EEG.task to export

### DIFF
--- a/pop_exportbids.m
+++ b/pop_exportbids.m
@@ -148,7 +148,7 @@ pInfo = {}; % each EEG file has its own pInfo --> need to aggregate
 if isfield(EEG(1), 'BIDS') && isfield(EEG(1).BIDS,'pInfo') 
     pInfo = EEG(1).BIDS.pInfo(1,:);
 end
-subjects = struct('file',{}, 'session', [], 'run', []);
+subjects = struct('file',{}, 'session', [], 'run', [], 'task', {});
 for iSubj = 1:length(uniqueSubjects)
     indS = strmatch( uniqueSubjects{iSubj}, allSubjects, 'exact' );
     for iFile = 1:length(indS)
@@ -162,6 +162,10 @@ for iSubj = 1:length(uniqueSubjects)
             subjects(iSubj).run(iFile) = EEG(indS(iFile)).run;
         else
             subjects(iSubj).run(iFile) = 1;  % Assume only one run
+        end
+        if isfield(EEG(indS(iFile)), 'task') && ~isempty(EEG(indS(iFile)).task)
+            subjects(iSubj).task{iFile} = EEG(indS(iFile)).task; 
+            % blank task field will be filled in bids_export.m
         end
     end
     if isfield(EEG(indS(1)), 'BIDS') && isfield(EEG(indS(1)).BIDS,'pInfo')

--- a/pop_importbids.m
+++ b/pop_importbids.m
@@ -412,7 +412,7 @@ for iSubject = 2:size(bids.participants,1)
                     EEG.subject = bids.participants{iSubject,1};
                     EEG.session = iFold;
                     EEG.run = iRun;
-                    EEG.task = task(6:end); %TODO
+                    EEG.task = task(6:end); % task is currently of format "task-<Task name>"
                     
                     % build `EEG.BIDS` from `bids`
                     BIDS.gInfo = bids.dataset_description;

--- a/pop_importbids.m
+++ b/pop_importbids.m
@@ -145,17 +145,17 @@ bids.participants = '';
 if exist(participantsFile,'File')
     bids.participants = importtsv( participantsFile );
 end
+% if no participants.tsv, use subjects folder names as their IDs
+if isempty(bids.participants)
+    participantFolders = dir(fullfile(bidsFolder, 'sub-*'));
+    bids.participants = {'participant_id' participantFolders.name }';
+end
 
-% load participant file
+% load participant sidecar file
 participantsJSONFile = fullfile(bidsFolder, 'participants.json');
 bids.participantsJSON = '';
 if exist(participantsJSONFile,'File')
     bids.participantsJSON = jsondecode(importalltxt( participantsJSONFile ));
-end
-
-if isempty(bids.participants)
-    participantFolders = dir(fullfile(bidsFolder, 'sub-*'));
-    bids.participants = {'dummyRow' participantFolders.name }';
 end
 
 % scan participants
@@ -406,17 +406,17 @@ for iSubject = 2:size(bids.participants,1)
                     EEG.subject = bids.participants{iSubject,1};
                     EEG.session = iFold;
                     EEG.run = iRun;
+                    EEG.task = task(6:end); %TODO
                     
                     % build `EEG.BIDS` from `bids`
                     BIDS.gInfo = bids.dataset_description;
                     BIDS.gInfo.README = bids.README;
-                    BIDS.pInfo = [bids.participants(1,:); bids.participants(iSubject,:)];
+                    BIDS.pInfo = [bids.participants(1,:); bids.participants(iSubject,:)]; % header -> iSubject info
                     BIDS.pInfoDesc = bids.participantsJSON;
 %                     BIDS.eInfo = ;
                     BIDS.eInfoDesc = bids.data.eventdesc;
                     BIDS.tInfo = infoData;
                     EEG.BIDS = BIDS;
-                    EEG.task = task(6:end);
                     
                     if strcmpi(opt.metadata, 'off')
                         if exist(subjectFolderOut{iFold},'dir') ~= 7


### PR DESCRIPTION
Here imported data will have a EEG.BIDS structure. `EEG.task` has also been added and is used for the filename when exporting.

I don't see a good way to build eInfo on import, any suggestions (or maybe this is not necessary)?