### PR TITLE
pop_exportbids: fill opts with EEG.BIDS

### DIFF
--- a/pop_exportbids.m
+++ b/pop_exportbids.m
@@ -175,6 +175,23 @@ end
 if ~isempty(pInfo)
     options = [options 'pInfo' {pInfo}];
 end
+
+% use other EEG.BIDS fields as input options
+if isfield(EEG(1), 'BIDS')
+    if isfield(EEG(1).BIDS,'pInfoDesc') && ~isempty(EEG(1).BIDS.pInfoDesc) 
+        pInfoDesc = EEG(1).BIDS.pInfoDesc;
+        options = [options 'pInfoDesc' {pInfoDesc}];
+    end
+    if isfield(EEG(1).BIDS,'eInfo') && ~isempty(EEG(1).BIDS.eInfo) 
+        eInfo = EEG(1).BIDS.eInfo;
+        options = [options 'eInfo' {eInfo}];
+    end
+    if isfield(EEG(1).BIDS,'eInfoDesc') && ~isempty(EEG(1).BIDS.eInfoDesc)
+        eInfoDesc = EEG(1).BIDS.eInfoDesc;
+        options = [options 'eInfoDesc' {eInfoDesc}];
+    end
+end
+
 bids_export(subjects, options{:});
 disp('Done');
 


### PR DESCRIPTION
We can use EEG.BIDS for export now, if it is found in the underlying EEG (built on import).
That said, I'm uncertain if `eInfo` and `eInfoDesc` can be pulled from the first dataset only (i.e. do different datasets within the same BIDS folder have different `eInfo` and `eInfoDesc`?). If yes, then the `eInfo` and `eInfoDesc` changes have to be made within bids_export as each file is loaded.