### PR TITLE
Update pop_exportbids.m to use EEG.BIDS

### DIFF
--- a/pop_exportbids.m
+++ b/pop_exportbids.m
@@ -87,22 +87,6 @@ if nargin < 3 && ~ischar(STUDY)
         EEG = pop_participantinfo(EEG, STUDY, 'default');
         EEG = pop_taskinfo(EEG, 'default');
     end
-    
-    % rearrange information in BIDS structures
-    if isfield(EEG(1).BIDS, 'gInfo') && isfield(EEG(1).BIDS.gInfo,'README') 
-        options = [options 'README' {EEG(1).BIDS.gInfo.README}];
-        EEG(1).BIDS.gInfo = rmfield(EEG(1).BIDS.gInfo,'README');
-    end
-    if isfield(EEG(1).BIDS, 'gInfo') && isfield(EEG(1).BIDS.gInfo,'TaskName') 
-        options = [options 'taskName' {EEG(1).BIDS.gInfo.TaskName}];
-        EEG(1).BIDS.gInfo = rmfield(EEG(1).BIDS.gInfo,'TaskName');
-    end
-    bidsFieldsFromALLEEG = fieldnames(EEG(1).BIDS); % All EEG should share same BIDS info -> using EEG(1)
-    for f=1:numel(bidsFieldsFromALLEEG)
-        options = [options bidsFieldsFromALLEEG{f} {EEG(1).BIDS.(bidsFieldsFromALLEEG{f})}];
-    end        
-
-    
 elseif ischar(STUDY)
     command = STUDY;
     fig = EEG;
@@ -121,6 +105,22 @@ elseif ischar(STUDY)
     return
 else
     options = varargin;
+end
+  
+% rearrange information in BIDS structures
+if isfield(EEG(1).BIDS, 'gInfo') && isfield(EEG(1).BIDS.gInfo,'README')
+    options = [options 'README' {EEG(1).BIDS.gInfo.README}];
+    EEG(1).BIDS.gInfo = rmfield(EEG(1).BIDS.gInfo,'README');
+end
+if isfield(EEG(1).BIDS, 'gInfo') && isfield(EEG(1).BIDS.gInfo,'TaskName')
+    options = [options 'taskName' {EEG(1).BIDS.gInfo.TaskName}];
+    EEG(1).BIDS.gInfo = rmfield(EEG(1).BIDS.gInfo,'TaskName');
+end
+
+bidsFieldsFromALLEEG = fieldnames(EEG(1).BIDS); % All EEG should share same BIDS info  -> using EEG(1)
+% tInfo.SubjectArtefactDescription is not shared, arguments passed as `notes` below
+for f=1:numel(bidsFieldsFromALLEEG)
+    options = [options bidsFieldsFromALLEEG{f} {EEG(1).BIDS.(bidsFieldsFromALLEEG{f})}];
 end
 
 % get subjects and sessions
@@ -166,6 +166,10 @@ for iSubj = 1:length(uniqueSubjects)
         if isfield(EEG(indS(iFile)), 'task') && ~isempty(EEG(indS(iFile)).task)
             subjects(iSubj).task{iFile} = EEG(indS(iFile)).task; 
             % blank task field will be filled in bids_export.m
+        end
+        if isfield(EEG(indS(iFile)).BIDS.tInfo, 'SubjectArtefactDescription')...
+                && ~isempty(EEG(indS(iFile)).BIDS.tInfo.SubjectArtefactDescription)
+            subjects(iSubj).notes{iFile} = EEG(indS(iFile)).BIDS.tInfo.SubjectArtefactDescription;
         end
     end
     if isfield(EEG(indS(1)), 'BIDS') && isfield(EEG(indS(1)).BIDS,'pInfo')


### PR DESCRIPTION
Lines that were previously only used for restructuring GUI inputs are now used regardless of whether the GUI was called or not:
1. cut and paste lines that use EEG.BIDS as inputs to `bids_export.m`
2. add line to handle `files.notes` (aka `tInfo.SubjectArtefactDescription`) since this is not shared between subjects

Double checking:
Are all EEG.BIDS fields correctly handled now? `pInfo` has its own aggregation code, `tInfo.SubjectArtefactDescription` is also handled correctly now as `notes`. What else needs special attention? Are `eInfo` or `eInfoDesc` consistent (no inconsistenty between each subject or each file?)