### PR TITLE
GUI update: reformat char to string for tInfo and gInfo

### DIFF
--- a/bids_export.m
+++ b/bids_export.m
@@ -481,7 +481,7 @@ end
 % ---------------------------
 if ~isempty(opt.README)
     if exist(opt.README) ~= 2
-        fid = fopen(fullfile(opt.targetdir, 'README.txt'), 'w');
+        fid = fopen(fullfile(opt.targetdir, 'README'), 'w');
         if fid == -1, error('Cannot write README file'); end
         fprintf(fid, '%s', opt.README);
         fclose(fid);

--- a/bids_export.m
+++ b/bids_export.m
@@ -481,7 +481,7 @@ end
 % ---------------------------
 if ~isempty(opt.README)
     if exist(opt.README) ~= 2
-        fid = fopen(fullfile(opt.targetdir, 'README'), 'w');
+        fid = fopen(fullfile(opt.targetdir, 'README.txt'), 'w');
         if fid == -1, error('Cannot write README file'); end
         fprintf(fid, '%s', opt.README);
         fclose(fid);

--- a/pop_taskinfo.m
+++ b/pop_taskinfo.m
@@ -192,7 +192,11 @@ function [EEG,com] = pop_taskinfo(EEG, varargin)
                             if strcmp(objs(i).Tag, 'ReferencesAndLinks') || strcmp(objs(i).Tag, 'Authors')
                                 gInfo.(objs(i).Tag) = {objs(i).String};
                             else
-                                gInfo.(objs(i).Tag) = objs(i).String;
+                                tmp = objs(i).String;
+                                if ndims(tmp) > 1 && size(tmp,1) > 1
+                                    tmp = reformatchartostring(tmp);                               
+                                end
+                                gInfo.(objs(i).Tag) = tmp;
                             end
                         else
                             if strcmp(objs(i).Style, 'popupmenu')
@@ -210,7 +214,11 @@ function [EEG,com] = pop_taskinfo(EEG, varargin)
                                     tmp.FilterDescription.Description = objs(i).String;
                                     tInfo.(objs(i).Tag) = tmp;
                                 else
-                                    tInfo.(objs(i).Tag) = objs(i).String;
+                                    tmp = objs(i).String;
+                                    if ndims(tmp) > 1 && size(tmp,1) > 1
+                                        tmp = reformatchartostring(tmp);
+                                    end
+                                    tInfo.(objs(i).Tag) = tmp;
                                 end
                             end
                         end
@@ -339,5 +347,11 @@ function [EEG,com] = pop_taskinfo(EEG, varargin)
     end
 
     function editedCB(src,event)
+    end
+
+    function string_out = reformatchartostring(char_in)
+        char_in(1:end-1,end+1) = newline;
+        char_in = char_in';
+        string_out = char_in(:)';
     end
 end


### PR DESCRIPTION
Thankfully because of dynamic field tags I only had to use `reformatchartostring` twice (once for gInfo, once for tInfo). Not sure if it would be more readable to shift more lines to the subfunction.

fix #95. also add .txt extension to README. tested to work with p300 dataset.