### PR TITLE
fixed the condition when run is nan

### DIFF
--- a/bids_export.m
+++ b/bids_export.m
@@ -737,7 +737,7 @@ for iSubj = 1:length(files)
             
             for iRun = 1:length(files(iSubj).run)
                 structOut = getElement(files(iSubj), iRun);
-                if isnan(files(iSubj).run{iRun})
+                if strcmp(files(iSubj).run{iRun},'NaN')
                     fileStr   = [ subjectStr  '_task-' char(files(iSubj).task(iRun)) ];
                 else
                     fileStr   = [ subjectStr  '_task-' char(files(iSubj).task(iRun)) '_run-' files(iSubj).run{iRun} ];
@@ -760,7 +760,7 @@ for iSubj = 1:length(files)
                 runindx = strmatch(uniqueSess{iSess}, files(iSubj).session, 'exact');
                 for iSet = runindx(:)'
                     structOut = getElement(files(iSubj), iSet);
-                    if isnan( files(iSubj).run{iSet} )
+                    if strcmp(files(iSubj).run{iSet},'NaN')
                         fileStr      = [ subjectStr '_ses-' files(iSubj).session{iSet} '_task-' char(files(iSubj).task(iSet)) ];
                     else
                         fileStr      = [ subjectStr '_ses-' files(iSubj).session{iSet} '_task-' char(files(iSubj).task(iSet)) '_run-' files(iSubj).run{iSet} ];


### PR DESCRIPTION
Runs are converted to character arrays on line 466 of `bids_export`. Therefore, it seems that `strcmp` is a more suitable condition to check if `run=='NaN'`.

Already checked with the HBN data. Results are available at `nemar/yahya/cmi_bids_R3_20`

Successful merge closes #184.