### PR TITLE
ensure onset and duration cols' precision

### DIFF
--- a/bids_writeeventfile.m
+++ b/bids_writeeventfile.m
@@ -154,11 +154,11 @@ if ~isempty(EEG.event)
                     
                     case 'onset'
                         onset = (EEG.event(iEvent).(tmpField)-1)/EEG.srate;
-                        str{end+1} = sprintf('%1.10f', onset);
+                        str{end+1} = num2str(onset, 10);
                         
                     case 'duration'
                         if isfield(EEG.event, tmpField) && ~isempty(EEG.event(iEvent).(tmpField))
-                            duration = num2str(EEG.event(iEvent).(tmpField)/EEG.srate, '%1.10f');
+                            duration = num2str(EEG.event(iEvent).(tmpField)/EEG.srate, 10);
                         else
                             duration = 'n/a';
                         end


### PR DESCRIPTION
Currently, the `onset` and `duration` columns are printed with 10 decimal places, irrespective of the actual precision of the original value; see the example below.

![image](https://github.com/sccn/bids-matlab-tools/assets/44906843/6da49b3a-3565-4fb4-9c39-ac7cde22c753)

With a simple change and accommodating for the **maximum** of 10 decimal places, we can only show the decimals that are actually meaningful in the data.

![image](https://github.com/sccn/bids-matlab-tools/assets/44906843/12188258-e406-4610-80fd-adc508c3079d)