### PR TITLE
Add EMG-BIDS import/export support with multiple coordinate systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ EEG-BIDS_testcases
 *.asv
 *~
 *.asv
+
+CLAUDE.md
+.DS_Store
+.context/
+.rules/

--- a/bids_check_regular_sampling.m
+++ b/bids_check_regular_sampling.m
@@ -27,7 +27,7 @@ if nargin < 1
 end
 
 if nargin < 2
-    tolerance = 0.15;  % 15% tolerance - resampling for <15% deviation may cause issues
+    tolerance = 0.01;  % 1% tolerance for regular sampling detection
 end
 
 if isempty(EEG.data)

--- a/bids_check_regular_sampling.m
+++ b/bids_check_regular_sampling.m
@@ -17,7 +17,7 @@
 %   checks if data has irregular timestamps and calculates the average
 %   frequency for potential resampling.
 %
-% Authors: Arnaud Delorme, 2025
+% Authors: Seyed Yahya Shirazi, 2025
 
 function [isRegular, avgFreq] = bids_check_regular_sampling(EEG, tolerance)
 

--- a/bids_check_regular_sampling.m
+++ b/bids_check_regular_sampling.m
@@ -1,0 +1,60 @@
+% BIDS_CHECK_REGULAR_SAMPLING - Check if EEG data has regular sampling
+%
+% Usage:
+%   [isRegular, avgFreq] = bids_check_regular_sampling(EEG)
+%   [isRegular, avgFreq] = bids_check_regular_sampling(EEG, tolerance)
+%
+% Inputs:
+%   EEG       - [struct] EEGLAB dataset structure
+%   tolerance - [float] acceptable deviation from regular sampling (default: 0.0001 = 0.01%)
+%
+% Outputs:
+%   isRegular - [boolean] true if sampling is regular within tolerance
+%   avgFreq   - [float] average sampling frequency in Hz
+%
+% Note:
+%   EDF and BDF formats require perfectly regular sampling. This function
+%   checks if data has irregular timestamps and calculates the average
+%   frequency for potential resampling.
+%
+% Authors: Arnaud Delorme, 2025
+
+function [isRegular, avgFreq] = bids_check_regular_sampling(EEG, tolerance)
+
+if nargin < 1
+    help bids_check_regular_sampling;
+    return;
+end
+
+if nargin < 2
+    tolerance = 0.0001;
+end
+
+if isempty(EEG.data)
+    error('EEG.data is empty');
+end
+
+if EEG.trials > 1
+    isRegular = true;
+    avgFreq = EEG.srate;
+    return;
+end
+
+if isfield(EEG, 'times') && length(EEG.times) > 1
+    intervals = diff(EEG.times);
+
+    if length(unique(intervals)) == 1
+        isRegular = true;
+        avgFreq = EEG.srate;
+        return;
+    end
+
+    avgInterval = mean(intervals);
+    maxDeviation = max(abs(intervals - avgInterval)) / avgInterval;
+
+    isRegular = maxDeviation < tolerance;
+    avgFreq = 1000 / avgInterval;
+else
+    isRegular = true;
+    avgFreq = EEG.srate;
+end

--- a/bids_check_regular_sampling.m
+++ b/bids_check_regular_sampling.m
@@ -27,7 +27,7 @@ if nargin < 1
 end
 
 if nargin < 2
-    tolerance = 0.0001;
+    tolerance = 0.15;  % 15% tolerance - resampling for <15% deviation may cause issues
 end
 
 if isempty(EEG.data)
@@ -53,7 +53,14 @@ if isfield(EEG, 'times') && length(EEG.times) > 1
     maxDeviation = max(abs(intervals - avgInterval)) / avgInterval;
 
     isRegular = maxDeviation < tolerance;
-    avgFreq = 1000 / avgInterval;
+    % Check if times are in seconds (continuous) or milliseconds (epoched)
+    if EEG.trials == 1 && avgInterval < 1
+        % Continuous data: times in seconds
+        avgFreq = 1 / avgInterval;
+    else
+        % Epoched data: times in milliseconds
+        avgFreq = 1000 / avgInterval;
+    end
 else
     isRegular = true;
     avgFreq = EEG.srate;

--- a/bids_export.m
+++ b/bids_export.m
@@ -981,21 +981,30 @@ if ischar(opt.chanlookup) && ~isempty(opt.chanlookup)
     EEG=pop_chanedit(EEG, 'lookup', opt.chanlookup);
 end
 
+% Set datatype before writing channel/electrode files
+if strcmpi(opt.modality, 'eeg')
+    EEG.etc.datatype = 'eeg';
+elseif strcmpi(opt.modality, 'ieeg')
+    EEG.etc.datatype = 'ieeg';
+elseif strcmpi(opt.modality, 'meg')
+    EEG.etc.datatype = 'meg';
+elseif strcmpi(opt.modality, 'emg')
+    EEG.etc.datatype = 'emg';
+end
+
 % Write electrode file information (electrodes.tsv and coordsystem.json)
 bids_writechanfile(EEG, fileOutRed);
 bids_writeelectrodefile(EEG, fileOutRed, 'export', opt.elecexport);
+
+% Write modality-specific info files
 if strcmpi(opt.modality, 'eeg')
     bids_writetinfofile(EEG, tInfo, notes, fileOutRed);
-    EEG.etc.datatype = 'eeg';
 elseif strcmpi(opt.modality, 'ieeg')
     bids_writeieegtinfofile(EEG, tInfo, notes, fileOutRed);
-    EEG.etc.datatype = 'ieeg';
 elseif strcmpi(opt.modality, 'meg')
     bids_writemegtinfofile(EEG, tInfo, notes, fileOutRed);
-    EEG.etc.datatype = 'meg';
 elseif strcmpi(opt.modality, 'emg')
     bids_writeemgtinfofile(EEG, tInfo, notes, fileOutRed);
-    EEG.etc.datatype = 'emg';
 end
 
 % write channel information

--- a/bids_export.m
+++ b/bids_export.m
@@ -1012,7 +1012,7 @@ end
 
 % Write electrode file information (electrodes.tsv and coordsystem.json)
 bids_writechanfile(EEG, fileOutRed);
-bids_writeelectrodefile(EEG, fileOutRed, 'export', opt.elecexport);
+bids_writeelectrodefile(EEG, fileOutRed, 'export', opt.elecexport, 'rootdir', opt.targetdir);
 
 % Write modality-specific info files
 if strcmpi(opt.modality, 'eeg')

--- a/bids_export.m
+++ b/bids_export.m
@@ -892,7 +892,7 @@ end
 fileOut = [fileBase '_' opt.modality ext];
 
 % select data subset
-EEG = eeg_selectsegment(EEG, 'eventtype', eventtype, 'eventindex', eventindex, 'timeoffset', timeoffset );        
+EEG = eeg_selectsegment(EEG, 'eventtype', eventtype, 'eventindex', eventindex, 'timeoffset', timeoffset );
 
 if ~isequal(opt.exportformat, 'same') || isequal(ext, '.set')
     % export data if necessary
@@ -900,6 +900,14 @@ if ~isequal(opt.exportformat, 'same') || isequal(ext, '.set')
     if isequal(opt.exportformat, 'eeglab')
         pop_saveset(EEG, 'filename', [ fileOutNoExt '.set' ], 'filepath', filePathTmp);
     else
+        if strcmpi(opt.exportformat, 'edf') || strcmpi(opt.exportformat, 'bdf')
+            [isRegular, avgFreq] = bids_check_regular_sampling(EEG);
+            if ~isRegular
+                targetFreq = round(avgFreq);
+                fprintf('Resampling data from irregular to regular %.0f Hz for EDF/BDF export\n', targetFreq);
+                EEG = pop_resample(EEG, targetFreq);
+            end
+        end
         pop_writeeeg(EEG, fullfile(filePathTmp, [ fileOutNoExt '.' opt.exportformat]), 'TYPE',upper(opt.exportformat));
     end
 else

--- a/bids_export.m
+++ b/bids_export.m
@@ -914,14 +914,10 @@ if ~isequal(opt.exportformat, 'same') || isequal(ext, '.set')
     if isequal(opt.exportformat, 'eeglab')
         pop_saveset(EEG, 'filename', [ fileOutNoExt '.set' ], 'filepath', filePathTmp);
     else
-        if strcmpi(opt.exportformat, 'edf') || strcmpi(opt.exportformat, 'bdf')
-            [isRegular, avgFreq] = bids_check_regular_sampling(EEG);
-            if ~isRegular
-                targetFreq = round(avgFreq);
-                fprintf('Resampling data from irregular to regular %.0f Hz for EDF/BDF export\n', targetFreq);
-                EEG = pop_resample(EEG, targetFreq);
-            end
-        end
+        % Note: EDF/BDF formats assume regular sampling and store only the sampling rate.
+        % Irregular timestamps in EEG.times are not preserved in EDF/BDF output.
+        % Event timing has already been mapped to sample indices during import.
+
         % For EMG (and other modalities), save without events in EDF
         % Events are saved separately in events.tsv
         if strcmpi(opt.modality, 'emg') && (strcmpi(opt.exportformat, 'edf') || strcmpi(opt.exportformat, 'bdf'))

--- a/bids_export.m
+++ b/bids_export.m
@@ -347,7 +347,7 @@ opt = finputcheck(varargin, {
     'rmtempfiles'  'string'  {'on' 'off'}    'on';
     'exportformat' 'string'  {'same' 'eeglab' 'edf' 'bdf'}    'eeglab';
     'individualEventsJson' 'string'  {'on' 'off'}    'off';
-    'modality'     'string'  {'ieeg' 'meg' 'eeg' 'auto'}       'auto';
+    'modality'     'string'  {'ieeg' 'meg' 'eeg' 'emg' 'auto'}       'auto';
     'README'       'string'  {}    '';
     'CHANGES'      'string'  {}    '' ;
     'copydata'     'integer' {}    [0 1]; % legacy, does nothing now
@@ -369,6 +369,13 @@ if ~isempty(opt.generatedBy)
 end
 if ~isempty(opt.sourceDatasets)
     opt.SourceDatasets = opt.sourceDatasets;
+end
+
+if strcmpi(opt.modality, 'emg')
+    if strcmpi(opt.exportformat, 'eeglab')
+        opt.exportformat = 'bdf';
+        fprintf('EMG data detected: changing export format to bdf\n');
+    end
 end
 
 % deleting folder
@@ -986,6 +993,9 @@ elseif strcmpi(opt.modality, 'ieeg')
 elseif strcmpi(opt.modality, 'meg')
     bids_writemegtinfofile(EEG, tInfo, notes, fileOutRed);
     EEG.etc.datatype = 'meg';
+elseif strcmpi(opt.modality, 'emg')
+    bids_writeemgtinfofile(EEG, tInfo, notes, fileOutRed);
+    EEG.etc.datatype = 'emg';
 end
 
 % write channel information

--- a/bids_importchanlocs.m
+++ b/bids_importchanlocs.m
@@ -55,6 +55,10 @@ function [EEG, channelData, elecData] = bids_importchanlocs(EEG, channelFile, el
             chanlocs(iChan-1).X = elecData{iChan,2};
             chanlocs(iChan-1).Y = elecData{iChan,3};
             chanlocs(iChan-1).Z = elecData{iChan,4};
+            % Import coordinate_system (5th column) if present (EMG)
+            if size(elecData,2) >= 5 && ~isempty(elecData{iChan,5}) && ~strcmpi(elecData{iChan,5}, 'n/a')
+                chanlocs(iChan-1).coordinate_system = elecData{iChan,5};
+            end
         end
     end
 

--- a/bids_importcoordsystemfile.m
+++ b/bids_importcoordsystemfile.m
@@ -57,11 +57,22 @@ for iCoord = 1:length(coordfile)
     coordData = bids_importjson(coordfile{iCoord}, '_coordsystem.json');
 
     % Parse space entity from filename
+    % Handles both subject-level and root-level (inheritance) patterns:
+    %   - Subject: sub-01_space-hand_coordsystem.json
+    %   - Root: space-leftForearm_coordsystem.json
     [~, filename, ~] = fileparts(coordfile{iCoord});
     spaceLabel = '';
+
+    % Try with prefix underscore first (subject-level)
     spaceMatch = regexp(filename, '_space-([a-zA-Z0-9]+)_', 'tokens');
     if ~isempty(spaceMatch)
         spaceLabel = spaceMatch{1}{1};
+    else
+        % Try without prefix underscore (root-level, BIDS inheritance)
+        spaceMatch = regexp(filename, '^space-([a-zA-Z0-9]+)_', 'tokens');
+        if ~isempty(spaceMatch)
+            spaceLabel = spaceMatch{1}{1};
+        end
     end
 
     % Add space label to coordData

--- a/bids_writechanfile.m
+++ b/bids_writechanfile.m
@@ -21,13 +21,17 @@
 function bids_writechanfile(EEG, fileOut)
 
 fid = fopen( [ fileOut '_channels.tsv' ], 'w');
+
+isEMG = isfield(EEG, 'etc') && isfield(EEG.etc, 'datatype') && strcmpi(EEG.etc.datatype, 'emg');
+isiEEG = isfield(EEG, 'etc') && isfield(EEG.etc, 'datatype') && strcmpi(EEG.etc.datatype, 'ieeg');
+
 if isempty(EEG.chanlocs)
-    if contains(fileOut, 'ieeg')
+    if isiEEG
         fprintf(fid, 'name\ttype\tunits\tlow_cutoff\thigh_cutoff\n');
         for iChan = 1:EEG.nbchan
             fprintf(fid, 'E%d\tiEEG\tmicroV\tn/a\tn/a\n', iChan);
         end
-    elseif contains(fileOut, 'emg')
+    elseif isEMG
         fprintf(fid, 'name\ttype\tunits\ttarget_muscle\n');
         for iChan = 1:EEG.nbchan
             fprintf(fid, 'E%d\tEMG\tV\tn/a\n', iChan);
@@ -40,9 +44,9 @@ if isempty(EEG.chanlocs)
     end
     channelsCount = struct([]);
 else
-    if contains(fileOut, 'ieeg')
+    if isiEEG
         fprintf(fid, 'name\ttype\tunits\tlow_cutoff\thigh_cutoff\n');
-    elseif contains(fileOut, 'emg')
+    elseif isEMG
         fprintf(fid, 'name\ttype\tunits\ttarget_muscle\n');
     else
         fprintf(fid, 'name\ttype\tunits\n');
@@ -69,9 +73,9 @@ else
         end
 
         %Write
-        if contains(fileOut, 'ieeg')
+        if isiEEG
             fprintf(fid, '%s\t%s\t%s\tn/a\tn/a\n', EEG.chanlocs(iChan).labels, type, unit);
-        elseif contains(fileOut, 'emg')
+        elseif isEMG
             if isfield(EEG.chanlocs(iChan), 'target_muscle') && ~isempty(EEG.chanlocs(iChan).target_muscle)
                 target_muscle = EEG.chanlocs(iChan).target_muscle;
             else

--- a/bids_writechanfile.m
+++ b/bids_writechanfile.m
@@ -32,9 +32,10 @@ if isempty(EEG.chanlocs)
             fprintf(fid, 'E%d\tiEEG\tmicroV\tn/a\tn/a\n', iChan);
         end
     elseif isEMG
-        fprintf(fid, 'name\ttype\tunits\ttarget_muscle\n');
+        % EMG - only write REQUIRED columns when no chanlocs
+        fprintf(fid, 'name\ttype\tunits\n');
         for iChan = 1:EEG.nbchan
-            fprintf(fid, 'E%d\tEMG\tV\tn/a\n', iChan);
+            fprintf(fid, 'E%d\tEMG\tV\n', iChan);
         end
     else
         fprintf(fid, 'name\ttype\tunits\n');
@@ -47,7 +48,8 @@ else
     if isiEEG
         fprintf(fid, 'name\ttype\tunits\tlow_cutoff\thigh_cutoff\n');
     elseif isEMG
-        fprintf(fid, 'name\ttype\tunits\ttarget_muscle\n');
+        % EMG with all RECOMMENDED columns
+        fprintf(fid, 'name\ttype\tunits\tsignal_electrode\treference\tgroup\ttarget_muscle\tplacement_scheme\tplacement_description\tinterelectrode_distance\tlow_cutoff\thigh_cutoff\tsampling_frequency\n');
     else
         fprintf(fid, 'name\ttype\tunits\n');
     end
@@ -76,15 +78,37 @@ else
         if isiEEG
             fprintf(fid, '%s\t%s\t%s\tn/a\tn/a\n', EEG.chanlocs(iChan).labels, type, unit);
         elseif isEMG
-            if isfield(EEG.chanlocs(iChan), 'target_muscle') && ~isempty(EEG.chanlocs(iChan).target_muscle)
-                target_muscle = EEG.chanlocs(iChan).target_muscle;
-            else
-                target_muscle = 'n/a';
-            end
-            fprintf(fid, '%s\t%s\t%s\t%s\n', EEG.chanlocs(iChan).labels, type, unit, target_muscle);
+            % Extract EMG-specific fields (RECOMMENDED columns)
+            signal_electrode = getfield_or_na(EEG.chanlocs(iChan), 'signal_electrode');
+            reference = getfield_or_na(EEG.chanlocs(iChan), 'reference');
+            group = getfield_or_na(EEG.chanlocs(iChan), 'group');
+            target_muscle = getfield_or_na(EEG.chanlocs(iChan), 'target_muscle');
+            placement_scheme = getfield_or_na(EEG.chanlocs(iChan), 'placement_scheme');
+            placement_description = getfield_or_na(EEG.chanlocs(iChan), 'placement_description');
+            interelectrode_distance = getfield_or_na(EEG.chanlocs(iChan), 'interelectrode_distance');
+            low_cutoff = getfield_or_na(EEG.chanlocs(iChan), 'low_cutoff');
+            high_cutoff = getfield_or_na(EEG.chanlocs(iChan), 'high_cutoff');
+            sampling_frequency = getfield_or_na(EEG.chanlocs(iChan), 'sampling_frequency');
+
+            fprintf(fid, '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n', ...
+                EEG.chanlocs(iChan).labels, type, unit, signal_electrode, reference, ...
+                group, target_muscle, placement_scheme, placement_description, ...
+                interelectrode_distance, low_cutoff, high_cutoff, sampling_frequency);
         else
             fprintf(fid, '%s\t%s\t%s\n', EEG.chanlocs(iChan).labels, type, unit);
         end
     end
 end
 fclose(fid);
+
+% Helper function to get field value or 'n/a'
+function value = getfield_or_na(struct, fieldname)
+if isfield(struct, fieldname) && ~isempty(struct.(fieldname))
+    value = struct.(fieldname);
+    % Convert numeric to string
+    if isnumeric(value)
+        value = num2str(value);
+    end
+else
+    value = 'n/a';
+end

--- a/bids_writechanfile.m
+++ b/bids_writechanfile.m
@@ -25,18 +25,25 @@ if isempty(EEG.chanlocs)
     if contains(fileOut, 'ieeg')
         fprintf(fid, 'name\ttype\tunits\tlow_cutoff\thigh_cutoff\n');
         for iChan = 1:EEG.nbchan
-            fprintf(fid, 'E%d\tiEEG\tmicroV\tn/a\tn/a\n', iChan); 
+            fprintf(fid, 'E%d\tiEEG\tmicroV\tn/a\tn/a\n', iChan);
+        end
+    elseif contains(fileOut, 'emg')
+        fprintf(fid, 'name\ttype\tunits\ttarget_muscle\n');
+        for iChan = 1:EEG.nbchan
+            fprintf(fid, 'E%d\tEMG\tV\tn/a\n', iChan);
         end
     else
         fprintf(fid, 'name\ttype\tunits\n');
         for iChan = 1:EEG.nbchan
-            fprintf(fid, 'E%d\tEEG\tmicroV\n', iChan); 
+            fprintf(fid, 'E%d\tEEG\tmicroV\n', iChan);
         end
     end
     channelsCount = struct([]);
 else
     if contains(fileOut, 'ieeg')
         fprintf(fid, 'name\ttype\tunits\tlow_cutoff\thigh_cutoff\n');
+    elseif contains(fileOut, 'emg')
+        fprintf(fid, 'name\ttype\tunits\ttarget_muscle\n');
     else
         fprintf(fid, 'name\ttype\tunits\n');
     end
@@ -64,6 +71,13 @@ else
         %Write
         if contains(fileOut, 'ieeg')
             fprintf(fid, '%s\t%s\t%s\tn/a\tn/a\n', EEG.chanlocs(iChan).labels, type, unit);
+        elseif contains(fileOut, 'emg')
+            if isfield(EEG.chanlocs(iChan), 'target_muscle') && ~isempty(EEG.chanlocs(iChan).target_muscle)
+                target_muscle = EEG.chanlocs(iChan).target_muscle;
+            else
+                target_muscle = 'n/a';
+            end
+            fprintf(fid, '%s\t%s\t%s\t%s\n', EEG.chanlocs(iChan).labels, type, unit, target_muscle);
         else
             fprintf(fid, '%s\t%s\t%s\n', EEG.chanlocs(iChan).labels, type, unit);
         end

--- a/bids_writeelectrodefile.m
+++ b/bids_writeelectrodefile.m
@@ -52,7 +52,7 @@ end
 if any(strcmp(flagExport, {'auto', 'on'})) && ~isempty(EEG.chanlocs) && isfield(EEG.chanlocs, 'X') && any(cellfun(@(x)~isempty(x), { EEG.chanlocs.X }))
     fid = fopen( [ fileOut '_electrodes.tsv' ], 'w');
     fprintf(fid, 'name\tx\ty\tz\n');
-    
+
     for iChan = 1:EEG.nbchan
         if isempty(EEG.chanlocs(iChan).X) || isnan(EEG.chanlocs(iChan).X) || contains(fileOut, 'ieeg')
             fprintf(fid, '%s\tn/a\tn/a\tn/a\n', EEG.chanlocs(iChan).labels );
@@ -61,22 +61,40 @@ if any(strcmp(flagExport, {'auto', 'on'})) && ~isempty(EEG.chanlocs) && isfield(
         end
     end
     fclose(fid);
-    
+
     % Write coordinate file information (coordsystem.json)
-    if isfield(EEG.chaninfo, 'BIDS') && isfield(EEG.chaninfo.BIDS, 'EEGCoordinateUnits')
-        coordsystemStruct.EEGCoordinateUnits = EEG.chaninfo.BIDS.EEGCoordinateUnits;
+    if contains(fileOut, 'emg')
+        if isfield(EEG.chaninfo, 'BIDS') && isfield(EEG.chaninfo.BIDS, 'EMGCoordinateUnits')
+            coordsystemStruct.EMGCoordinateUnits = EEG.chaninfo.BIDS.EMGCoordinateUnits;
+        else
+            coordsystemStruct.EMGCoordinateUnits = 'mm';
+        end
+        if isfield(EEG.chaninfo, 'BIDS') && isfield(EEG.chaninfo.BIDS, 'EMGCoordinateSystem')
+            coordsystemStruct.EMGCoordinateSystem = EEG.chaninfo.BIDS.EMGCoordinateSystem;
+        else
+            coordsystemStruct.EMGCoordinateSystem = 'Other';
+        end
+        if isfield(EEG.chaninfo, 'BIDS') && isfield(EEG.chaninfo.BIDS, 'EMGCoordinateSystemDescription')
+            coordsystemStruct.EMGCoordinateSystemDescription = EEG.chaninfo.BIDS.EMGCoordinateSystemDescription;
+        else
+            coordsystemStruct.EMGCoordinateSystemDescription = 'Electrode locations in mm';
+        end
     else
-        coordsystemStruct.EEGCoordinateUnits = 'mm';
-    end
-    if isfield(EEG.chaninfo, 'BIDS') &&isfield(EEG.chaninfo.BIDS, 'EEGCoordinateSystem')
-        coordsystemStruct.EEGCoordinateSystem = EEG.chaninfo.BIDS.EEGCoordinateSystem;
-    else
-        coordsystemStruct.EEGCoordinateSystem = 'CTF';
-    end
-    if isfield(EEG.chaninfo, 'BIDS') &&isfield(EEG.chaninfo.BIDS, 'EEGCoordinateSystemDescription')
-        coordsystemStruct.EEGCoordinateSystemDescription = EEG.chaninfo.BIDS.EEGCoordinateSystemDescription;
-    else
-        coordsystemStruct.EEGCoordinateSystemDescription = 'EEGLAB';
+        if isfield(EEG.chaninfo, 'BIDS') && isfield(EEG.chaninfo.BIDS, 'EEGCoordinateUnits')
+            coordsystemStruct.EEGCoordinateUnits = EEG.chaninfo.BIDS.EEGCoordinateUnits;
+        else
+            coordsystemStruct.EEGCoordinateUnits = 'mm';
+        end
+        if isfield(EEG.chaninfo, 'BIDS') &&isfield(EEG.chaninfo.BIDS, 'EEGCoordinateSystem')
+            coordsystemStruct.EEGCoordinateSystem = EEG.chaninfo.BIDS.EEGCoordinateSystem;
+        else
+            coordsystemStruct.EEGCoordinateSystem = 'CTF';
+        end
+        if isfield(EEG.chaninfo, 'BIDS') &&isfield(EEG.chaninfo.BIDS, 'EEGCoordinateSystemDescription')
+            coordsystemStruct.EEGCoordinateSystemDescription = EEG.chaninfo.BIDS.EEGCoordinateSystemDescription;
+        else
+            coordsystemStruct.EEGCoordinateSystemDescription = 'EEGLAB';
+        end
     end
     jsonwrite( [ fileOut '_coordsystem.json' ], coordsystemStruct);
 end

--- a/bids_writeelectrodefile.m
+++ b/bids_writeelectrodefile.m
@@ -63,7 +63,9 @@ if any(strcmp(flagExport, {'auto', 'on'})) && ~isempty(EEG.chanlocs) && isfield(
     fclose(fid);
 
     % Write coordinate file information (coordsystem.json)
-    if contains(fileOut, 'emg')
+    isEMG = isfield(EEG, 'etc') && isfield(EEG.etc, 'datatype') && strcmpi(EEG.etc.datatype, 'emg');
+
+    if isEMG
         if isfield(EEG.chaninfo, 'BIDS') && isfield(EEG.chaninfo.BIDS, 'EMGCoordinateUnits')
             coordsystemStruct.EMGCoordinateUnits = EEG.chaninfo.BIDS.EMGCoordinateUnits;
         else

--- a/bids_writeelectrodefile.m
+++ b/bids_writeelectrodefile.m
@@ -241,7 +241,7 @@ if any(strcmp(flagExport, {'auto', 'on'})) && ~isempty(EEG.chanlocs) && isfield(
             else
                 filename = sprintf('%s_coordsystem.json', fileOut);
             end
-            jsonwrite(filename, coordStruct);
+            jsonwrite(filename, coordStruct, struct('indent','  '));
         end
     else
         % Single coordinate system (backward compatibility)
@@ -280,7 +280,7 @@ if any(strcmp(flagExport, {'auto', 'on'})) && ~isempty(EEG.chanlocs) && isfield(
                 coordsystemStruct.EEGCoordinateSystemDescription = 'EEGLAB';
             end
         end
-        jsonwrite( [ fileOut '_coordsystem.json' ], coordsystemStruct);
+        jsonwrite( [ fileOut '_coordsystem.json' ], coordsystemStruct, struct('indent','  '));
     end
 end
 

--- a/bids_writeemgtinfofile.m
+++ b/bids_writeemgtinfofile.m
@@ -10,8 +10,6 @@
 %  fileOut   - [string] filepath of the desired output location with file basename
 %                e.g. ~/BIDS_EXPORT/sub-01/ses-01/emg/sub-01_ses-01_task-holdWeight
 %
-% Copyright (C) 2025, Seyed Yahya Shirazi, SCCN, INC, UCSD
-%
 % Authors: Seyed Yahya Shirazi, 2025
 
 function tInfo = bids_writeemgtinfofile(EEG, tInfo, notes, fileOutRed)

--- a/bids_writeemgtinfofile.m
+++ b/bids_writeemgtinfofile.m
@@ -1,0 +1,99 @@
+% BIDS_WRITEEMGTINFOFILE - write tinfo file for EMG data
+%
+% Usage:
+%    bids_writeemgtinfofile(EEG, tinfo, notes, fileOut)
+%
+% Inputs:
+%  EEG       - [struct] EEGLAB dataset information
+%  tinfo     - [struct] structure containing task information
+%  notes     - [string] notes to store along with the data info
+%  fileOut   - [string] filepath of the desired output location with file basename
+%                e.g. ~/BIDS_EXPORT/sub-01/ses-01/emg/sub-01_ses-01_task-holdWeight
+%
+% Copyright (C) 2025, Seyed Yahya Shirazi, SCCN, INC, UCSD
+%
+% Authors: Seyed Yahya Shirazi, 2025
+
+function tInfo = bids_writeemgtinfofile(EEG, tInfo, notes, fileOutRed)
+
+[~,channelsCount] = eeg_getchantype(EEG);
+
+nonEmptyChannelTypes = fieldnames(channelsCount);
+for i=1:numel(nonEmptyChannelTypes)
+    if strcmp(nonEmptyChannelTypes{i}, 'MISC')
+        tInfo.('MiscChannelCount') = channelsCount.('MISC');
+    else
+        tInfo.([nonEmptyChannelTypes{i} 'ChannelCount']) = channelsCount.(nonEmptyChannelTypes{i});
+    end
+end
+
+if ~isfield(tInfo, 'EMGReference')
+    if ~ischar(EEG.ref) && numel(EEG.ref) > 1
+        refChanLocs = EEG.chanlocs(EEG.ref);
+        ref = join({refChanLocs.labels},',');
+        ref = ref{1};
+    else
+        ref = EEG.ref;
+    end
+    tInfo.EMGReference = ref;
+end
+
+if EEG.trials == 1
+    tInfo.RecordingType = 'continuous';
+    tInfo.RecordingDuration = EEG.pnts/EEG.srate;
+else
+    tInfo.RecordingType = 'epoched';
+    tInfo.EpochLength = EEG.pnts/EEG.srate;
+    tInfo.RecordingDuration = (EEG.pnts/EEG.srate)*EEG.trials;
+end
+
+tInfo.SamplingFrequency = EEG.srate;
+
+if ~isempty(notes)
+    tInfo.SubjectArtefactDescription = notes;
+end
+
+tInfoFields = {...
+    'TaskName' 'REQUIRED' 'char' '';
+    'TaskDescription' 'RECOMMENDED' 'char' '';
+    'Instructions' 'RECOMMENDED' 'char' '';
+    'CogAtlasID' 'RECOMMENDED' 'char' '';
+    'CogPOID' 'RECOMMENDED' 'char' '';
+    'InstitutionName' 'RECOMMENDED' 'char' '';
+    'InstitutionAddress' 'RECOMMENDED' 'char' '';
+    'InstitutionalDepartmentName' 'RECOMMENDED' 'char' '';
+    'DeviceSerialNumber' 'RECOMMENDED' 'char' '';
+    'SamplingFrequency' 'REQUIRED' '' '';
+    'EMGChannelCount' 'RECOMMENDED' '' '';
+    'EOGChannelCount' 'RECOMMENDED' '' 0;
+    'ECGChannelCount' 'RECOMMENDED' '' 0;
+    'EMGReference' 'REQUIRED' 'char' 'Unknown';
+    'EMGGround' 'RECOMMENDED' 'char' '';
+    'EMGPlacementScheme' 'REQUIRED' 'char' 'Other';
+    'EMGPlacementSchemeDescription' 'RECOMMENDED' 'char' '';
+    'PowerLineFrequency' 'REQUIRED' '' 'n/a';
+    'MiscChannelCount' 'OPTIONAL' '' '';
+    'TriggerChannelCount' 'RECOMMENDED' '' '';
+    'Manufacturer' 'RECOMMENDED' 'char' '';
+    'ManufacturersModelName' 'OPTIONAL' 'char' '';
+    'ElectrodeManufacturer' 'RECOMMENDED' 'char' '';
+    'ElectrodeManufacturersModelName' 'RECOMMENDED' 'char' '';
+    'ElectrodeType' 'RECOMMENDED' 'char' '';
+    'ElectrodeMaterial' 'RECOMMENDED' 'char' '';
+    'InterelectrodeDistance' 'RECOMMENDED' '' '';
+    'HardwareFilters' 'OPTIONAL' 'struct' 'n/a';
+    'SoftwareFilters' 'REQUIRED' 'struct' 'n/a';
+    'RecordingDuration' 'RECOMMENDED' '' 'n/a';
+    'RecordingType' 'RECOMMENDED' 'char' '';
+    'EpochLength' 'RECOMMENDED' '' 'n/a';
+    'SoftwareVersions' 'RECOMMENDED' 'char' '';
+    'SubjectArtefactDescription' 'OPTIONAL' 'char' '';
+    'SkinPreparation' 'OPTIONAL' 'char' ''};
+
+tInfo = bids_checkfields(tInfo, tInfoFields, 'tInfo');
+
+if any(contains(tInfo.TaskName, '_')) || any(contains(tInfo.TaskName, ' '))
+    error('Task name cannot contain underscore or space character(s)');
+end
+
+jsonwrite([fileOutRed '_emg.json'], tInfo, struct('indent','  '));

--- a/eeg_import.m
+++ b/eeg_import.m
@@ -91,8 +91,15 @@ elseif strcmpi(ext, '.vhdr')
     [fpathin, fname, ext] = fileparts(fileIn);
     EEG = pop_loadbv(fpathin, [fname ext]);
 elseif strcmpi(ext, '.set')
-    if strcmpi(opt.modality, 'auto'), opt.modality = 'eeg'; end
     EEG = pop_loadset(fileIn);
+    if strcmpi(opt.modality, 'auto')
+        % Check EEG.etc.datatype to determine actual modality
+        if isfield(EEG, 'etc') && isfield(EEG.etc, 'datatype') && ~isempty(EEG.etc.datatype)
+            opt.modality = lower(EEG.etc.datatype);
+        else
+            opt.modality = 'eeg';
+        end
+    end
 elseif strcmpi(ext, '.cnt')
     if strcmpi(opt.modality, 'auto'), opt.modality = 'eeg'; end
     EEG = pop_loadcnt(fileIn, 'dataformat', 'auto');

--- a/eeg_import.m
+++ b/eeg_import.m
@@ -74,7 +74,7 @@ opt = finputcheck(varargin, {
     'ctffunc'      'string'    { 'fileio' 'ctfimport' }    'fileio'; ...
     'importfunc'   ''  {}    '';
     'importfunc'   ''  {}    '';
-    'modality'     'string'  {'ieeg' 'meg' 'eeg' 'auto'}       'auto';
+    'modality'     'string'  {'ieeg' 'meg' 'eeg' 'emg' 'auto'}       'auto';
     'noevents'     'string'  {'on' 'off'}    'off' }, 'eeg_import');
 if isstr(opt), error(opt); end
 

--- a/pop_importbids.m
+++ b/pop_importbids.m
@@ -298,6 +298,10 @@ for iSubject = opt.subjects
             if ~exist(subjectFolder{iFold},'dir')
                 subjectFolder{   iFold} = fullfile(parentSubjectFolder, subFolders{iFold}, 'ieeg');
                 subjectFolderOut{iFold} = fullfile(outputSubjectFolder, subFolders{iFold}, 'ieeg');
+                if ~exist(subjectFolder{iFold},'dir')
+                    subjectFolder{   iFold} = fullfile(parentSubjectFolder, subFolders{iFold}, 'emg');
+                    subjectFolderOut{iFold} = fullfile(outputSubjectFolder, subFolders{iFold}, 'emg');
+                end
             end
         end
     end
@@ -338,7 +342,20 @@ for iSubject = opt.subjects
             if isempty(eegFile)
                 eegFile     = searchparent(subjectFolder{iFold}, '*_ieeg.*');
             end
+            if isempty(eegFile)
+                eegFile     = searchparent(subjectFolder{iFold}, '*_emg.*');
+            end
+            % Search for modality-specific JSON file (eeg, ieeg, meg, or emg)
             infoFile      = searchparent(subjectFolder{iFold}, '*_eeg.json');
+            if isempty(infoFile)
+                infoFile  = searchparent(subjectFolder{iFold}, '*_ieeg.json');
+            end
+            if isempty(infoFile)
+                infoFile  = searchparent(subjectFolder{iFold}, '*_meg.json');
+            end
+            if isempty(infoFile)
+                infoFile  = searchparent(subjectFolder{iFold}, '*_emg.json');
+            end
             channelFile   = searchparent(subjectFolder{iFold}, '*_channels.tsv');
             elecFile      = searchparent(subjectFolder{iFold}, '*_electrodes.tsv');
             eventFile     = searchparent(subjectFolder{iFold}, '*_events.tsv');
@@ -495,7 +512,11 @@ for iSubject = opt.subjects
                         if ~strcmpi(tmpFileName(underScores(end)+1:end), 'eeg')
                             if ~strcmpi(tmpFileName(underScores(end)+1:end), 'meg.fif')
                                 if ~strcmpi(tmpFileName(underScores(end)+1:end), 'meg')
-                                    error('Data file name does not contain eeg, ieeg, or meg'); % theoretically impossible
+                                    if ~strcmpi(tmpFileName(underScores(end)+1:end), 'emg')
+                                        error('Data file name does not contain eeg, ieeg, meg, or emg');
+                                    else
+                                        modality = 'emg';
+                                    end
                                 else
                                     modality = 'meg';
                                 end

--- a/pop_importbids.m
+++ b/pop_importbids.m
@@ -78,7 +78,7 @@ if nargin < 1
     
     disp('Scanning folders...');
     % scan if multiple tasks are present
-    [tasklist,sessions,runs] = bids_getinfofromfolder(bidsFolder);
+    [tasklist,sessions,runs,recordings] = bids_getinfofromfolder(bidsFolder);
     % scan for event fields
     type_fields = bids_geteventfieldsfromfolder(bidsFolder);
     indVal = strmatch('value', type_fields);
@@ -91,11 +91,12 @@ if nargin < 1
     if isempty(type_fields) type_fields = { 'n/a' }; end
     if isempty(tasklist) tasklist = { 'n/a' }; end
     
-    cb_event    = 'set(findobj(gcbf, ''userdata'', ''bidstype''), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
-    cb_task     = 'set(findobj(gcbf, ''userdata'', ''task''    ), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
-    cb_sess     = 'set(findobj(gcbf, ''userdata'', ''sessions''), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
-    cb_run      = 'set(findobj(gcbf, ''userdata'', ''runs''    ), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
-    cb_subjects = 'set(findobj(gcbf, ''userdata'', ''subjects''), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
+    cb_event     = 'set(findobj(gcbf, ''userdata'', ''bidstype''), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
+    cb_task      = 'set(findobj(gcbf, ''userdata'', ''task''    ), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
+    cb_sess      = 'set(findobj(gcbf, ''userdata'', ''sessions''), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
+    cb_run       = 'set(findobj(gcbf, ''userdata'', ''runs''    ), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
+    cb_recording = 'set(findobj(gcbf, ''userdata'', ''recordings''), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
+    cb_subjects  = 'set(findobj(gcbf, ''userdata'', ''subjects''), ''enable'', fastif(get(gcbo, ''value''), ''on'', ''off''));';
     promptstr    = { ...
         { 'style'  'text'       'string' 'Enter study name (default is BIDS folder name)' } ...
         { 'style'  'edit'       'string' '' 'tag' 'studyName' } ...
@@ -109,6 +110,8 @@ if nargin < 1
         { 'style'  'listbox'    'string' sessions 'tag' 'bidsessionstr' 'max' 2 'value' [] 'userdata' 'sessions'  'enable' 'off' } {} ...
         { 'style'  'checkbox'   'string' 'Import only the following runs' 'tag' 'bidsruns' 'value' 0 'callback' cb_run }  ...
         { 'style'  'listbox'    'string' runs 'tag' 'bidsrunsstr' 'max' 2 'value' [] 'userdata' 'runs'  'enable' 'off' } {} ...
+        { 'style'  'checkbox'   'string' 'Import only the following recordings (multi-device)' 'tag' 'bidsrecordings' 'value' 0 'callback' cb_recording }  ...
+        { 'style'  'listbox'    'string' recordings 'tag' 'bidsrecordingsstr' 'max' 2 'value' [] 'userdata' 'recordings'  'enable' 'off' } {} ...
         { 'style'  'checkbox'   'string' 'Import only the following participant indices' 'tag' 'bidssubjects' 'value' 0 'callback' cb_subjects }  ...
         { 'style'  'edit'       'string' '' 'tag' 'bidssubjectsstr' 'userdata' 'subjects'  'enable' 'off' } {} ...
         {} ...
@@ -116,15 +119,20 @@ if nargin < 1
         { 'style'  'edit'       'string' fullfile(bidsFolder, 'derivatives', 'eeglab') 'tag' 'folder' 'HorizontalAlignment' 'left' } ...
         { 'style'  'pushbutton' 'string' '...' 'callback' cb_select } ...
         };
-    geometry = {[2 1.5], 1, 1,[1 0.35],[0.6 0.35 0.5],[0.6 0.35 0.5],[0.6 0.35 0.5],[0.6 0.35 0.5],1,[1 2 0.5]};
-    geomvert = [1 0.5, 1 1 1 1.5 1.5 1 0.5 1];
-    if isempty(runs)
+    geometry = {[2 1.5], 1, 1,[1 0.35],[0.6 0.35 0.5],[0.6 0.35 0.5],[0.6 0.35 0.5],[0.6 0.35 0.5],[0.6 0.35 0.5],1,[1 2 0.5]};
+    geomvert = [1 0.5, 1 1 1 1.5 1.5 1.5 1 0.5 1];
+    if isempty(recordings)
         promptstr(13:15) = [];
+        geometry(8) = [];
+        geomvert(8) = [];
+    end
+    if isempty(runs)
+        promptstr(10:12) = [];
         geometry(7) = [];
         geomvert(7) = [];
     end
     if isempty(sessions)
-        promptstr(10:12) = [];
+        promptstr(7:9) = [];
         geometry(6) = [];
         geomvert(6) = [];
     end
@@ -142,10 +150,13 @@ if nargin < 1
         if res.bidssessions && ~isempty(res.bidsessionstr),  options = { options{:} 'sessions' sessions(res.bidsessionstr) }; end
     end
     if isfield(res, 'bidsruns')
-        if res.bidsruns && ~isempty(res.bidsruns),  options = { options{:} 'runs' str2double(runs(res.bidsrunsstr)) }; end
+        if res.bidsruns && ~isempty(res.bidsrunsstr),  options = { options{:} 'runs' str2double(runs(res.bidsrunsstr)) }; end
+    end
+    if isfield(res, 'bidsrecordings')
+        if res.bidsrecordings && ~isempty(res.bidsrecordingsstr),  options = { options{:} 'recordings' recordings(res.bidsrecordingsstr) }; end
     end
     if isfield(res, 'bidssubjects')
-        if res.bidssubjects && ~isempty(res.bidssubjects),  options = { options{:} 'subjects' str2double(res.bidssubjectsstr) }; end
+        if res.bidssubjects && ~isempty(res.bidssubjectsstr),  options = { options{:} 'subjects' str2double(res.bidssubjectsstr) }; end
     end
 else
     options = varargin;
@@ -160,6 +171,7 @@ opt = finputcheck(options, { ...
     'subjects'       {'cell' 'integer'}   {{},[]}  []; ...
     'sessions'       'cell'      {}                {}; ...
     'runs'           {'cell' 'integer'}   {{},[]}  []; ...
+    'recordings'     'cell'      {}                {}; ...
     'metadata'       'string'    { 'on' 'off' }    'off'; ...
     'ctffunc'        'string'    { 'fileio' 'ctfimport' }    'fileio'; ...
     'eventtype'      'string'    {  }              'value'; ...
@@ -382,7 +394,7 @@ for iSubject = opt.subjects
                 behFile       = filterFiles(behFile      , opt.bidstask);
             end
             
-            % check the task
+            % check the runs
             if ~isempty(opt.runs)
                 eegFile       = filterFilesRun(eegFile      , opt.runs);
                 infoFile      = filterFilesRun(infoFile     , opt.runs);
@@ -391,6 +403,18 @@ for iSubject = opt.subjects
                 eventFile     = filterFilesRun(eventFile    , opt.runs);
                 eventDescFile = filterFilesRun(eventDescFile, opt.runs);
                 % no runs for BEH or coordsystem
+            end
+
+            % check the recordings (multi-device)
+            if ~isempty(opt.recordings)
+                eegFile       = filterFilesRecording(eegFile      , opt.recordings);
+                infoFile      = filterFilesRecording(infoFile     , opt.recordings);
+                channelFile   = filterFilesRecording(channelFile  , opt.recordings);
+                elecFile      = filterFilesRecording(elecFile     , opt.recordings);
+                eventFile     = filterFilesRecording(eventFile    , opt.recordings);
+                eventDescFile = filterFilesRecording(eventDescFile, opt.recordings);
+                coordFile     = filterFilesRecording(coordFile    , opt.recordings);
+                % events and coords may or may not have recording entity
             end
             
             % raw data
@@ -432,7 +456,33 @@ for iSubject = opt.subjects
                 end
                 eegFileRawAll  = allFiles(ind);
             end
-            
+
+            % Check for multiple recordings (multi-device acquisitions)
+            if length(eegFileRawAll) > 1
+                recordingDetected = cellfun(@(x)contains(x, '_recording-'), eegFileRawAll);
+                if any(recordingDetected)
+                    recordingLabels = {};
+                    for iR = 1:length(eegFileRawAll)
+                        if recordingDetected(iR)
+                            indRec = strfind(eegFileRawAll{iR}, '_recording-');
+                            tmpStr = eegFileRawAll{iR}(indRec(1)+11:end);
+                            indUnder = find(tmpStr == '_');
+                            if ~isempty(indUnder)
+                                recordingLabels{end+1} = tmpStr(1:indUnder(1)-1);
+                            else
+                                [~,~,ext] = fileparts(tmpStr);
+                                recordingLabels{end+1} = tmpStr(1:end-length(ext));
+                            end
+                        end
+                    end
+                    if ~isempty(recordingLabels)
+                        fprintf('Detected %d recordings with recording entity: %s\n', ...
+                                length(recordingLabels), strjoin(recordingLabels, ', '));
+                        fprintf('  → Importing each recording as a separate dataset\n');
+                    end
+                end
+            end
+
             % identify non-EEG data files
             %--------------------------------------------------------------
             if ~isempty(behFile) % should be a single file
@@ -480,9 +530,28 @@ for iSubject = opt.subjects
                         if isnan(iRun)
                             iRun = str2double(tmpEegFileRaw(1:indUnder(1)-2)); % rare case run 5H in ds003190/sub-01/ses-01/eeg/sub-01_ses-01_task-ctos_run-5H_eeg.eeg
                             if isnan(iRun)
-                                error('Problem converting run information'); 
+                                error('Problem converting run information');
                             end
                         end
+                    end
+
+                    % what is the recording entity (for multi-device EMG)
+                    recordingLabel = '';
+                    indRec = strfind(eegFileRaw, '_recording-');
+                    if ~isempty(indRec)
+                        tmpEegFileRaw = eegFileRaw(indRec(1)+11:end);
+                        indUnder = find(tmpEegFileRaw == '_');
+                        if ~isempty(indUnder)
+                            recordingLabel = tmpEegFileRaw(1:indUnder(1)-1);
+                        else
+                            % recording is last entity before extension
+                            [~,~,ext] = fileparts(tmpEegFileRaw);
+                            recordingLabel = tmpEegFileRaw(1:end-length(ext));
+                        end
+                    end
+
+                    % check for BEH file (run-specific)
+                    if ~isempty(ind)
                         % check for BEH file
                         filePathTmp = fileparts(eegFileRaw);
                         behFileTmp = fullfile(filePathTmp,'..', 'beh', [eegFileRaw(1:ind(1)-1) '_beh.tsv' ]);
@@ -655,7 +724,10 @@ for iSubject = opt.subjects
                         EEG.session = iFold;
                         EEG.run = iRun;
                         EEG.task = task(6:end); % task is currently of format "task-<Task name>"
-                        
+                        if ~isempty(recordingLabel)
+                            EEG.recording = recordingLabel;
+                        end
+
                         % build `EEG.BIDS` from `bids`
                         BIDS.gInfo = bids.dataset_description;
                         BIDS.gInfo.README = bids.README;
@@ -686,7 +758,10 @@ for iSubject = opt.subjects
                     
                     % building study command
                     commands = [ commands { 'index' count 'load' eegFileNameOut 'subject' bids.participants{iSubject,pInd} 'session' iFold 'task' task(6:end) 'run' iRun } ];
-                    
+                    if ~isempty(recordingLabel)
+                        commands = [ commands { 'recording' recordingLabel } ];
+                    end
+
                     % custom numerical fields
                     for iCol = 2:size(bids.participants,2)
                         commands = [ commands { bids.participants{1,iCol} bids.participants{iSubject,iCol} } ];
@@ -865,17 +940,15 @@ if ~iscell(runs)
     runs = {runs}; % integer now in a cell
 end
 keepInd = arrayfun(@(x) contains(extractAfter(x.name,'run-'),runs), fileList);
-% keepInd = zeros(1,length(fileList));
-% for iFile = 1:length(fileList)
-%     runInd = strfind(fileList(iFile).name, '_run-');
-%     if ~isempty(runInd)
-%         strTmp = fileList(iFile).name(runInd+5:end);
-%         underScore = find(strTmp == '_');
-%         if any(runs == str2double(strTmp(1:underScore(1)-1)))
-%             keepInd(iFile) = 1;
-%         end
-%     end
-% end
+fileList = fileList(logical(keepInd));
+
+% filter files by recording entity
+% ---------------------------------
+function fileList = filterFilesRecording(fileList, recordings)
+if ~iscell(recordings)
+    recordings = {recordings};
+end
+keepInd = arrayfun(@(x) contains(extractAfter(x.name,'recording-'),recordings), fileList);
 fileList = fileList(logical(keepInd));
 
 

--- a/pop_importbids.m
+++ b/pop_importbids.m
@@ -299,7 +299,7 @@ for iSubject = opt.subjects
     subjectFolderOut = {};
     if ~isempty(opt.sessions)
         subFolders = intersect(subFolders, opt.sessions);
-    end        
+    end
 
     for iFold = 1:length(subFolders)
         subjectFolder{   iFold} = fullfile(parentSubjectFolder, subFolders{iFold}, 'eeg');
@@ -712,11 +712,13 @@ for iSubject = opt.subjects
 			                end
                         end
                         
-                        % coordsystem file
-                        % ----------------
+                        % coordsystem file(s)
+                        % -------------------
                         if strcmpi(opt.bidscoord, 'on')
-                            coordFile = bids_get_file(eegFileRaw(1:end-8), '_coordsystem.json', coordFile);                   
-                            [EEG, bids] = bids_importcoordsystemfile(EEG, coordFile, 'bids', bids); 
+                            % Get all coordsystem files for this subject/session
+                            % Could be single (_coordsystem.json) or multiple (_space-*_coordsystem.json)
+                            coordFiles = bids_get_all_coordsystem_files(eegFileRaw(1:end-8), coordFile);
+                            [EEG, bids] = bids_importcoordsystemfile(EEG, coordFiles, 'bids', bids);
                         end
     
                         % copy information inside dataset
@@ -974,6 +976,16 @@ else
         if exist(tmpFile, 'file')
             filestr = tmpFile;
         end
+    end
+end
+
+% get all coordsystem files (single or multiple with space entity)
+function coordFiles = bids_get_all_coordsystem_files(baseName, coordFileStruct)
+coordFiles = {};
+if ~isempty(coordFileStruct) && isfield(coordFileStruct, 'folder') && isfield(coordFileStruct, 'name')
+    % Return all coordsystem files found (could be single or multiple with space)
+    for i = 1:length(coordFileStruct)
+        coordFiles{end+1} = fullfile(coordFileStruct(i).folder, coordFileStruct(i).name);
     end
 end
 

--- a/pop_importbids.m
+++ b/pop_importbids.m
@@ -729,6 +729,8 @@ for iSubject = opt.subjects
                         if ~isempty(recordingLabel)
                             EEG.recording = recordingLabel;
                         end
+                        % Set datatype for export
+                        EEG.etc.datatype = modality;
 
                         % build `EEG.BIDS` from `bids`
                         BIDS.gInfo = bids.dataset_description;

--- a/pop_importbids.m
+++ b/pop_importbids.m
@@ -502,6 +502,8 @@ for iSubject = opt.subjects
                             else
                                 modality = 'meg';
                             end
+                        elseif contains(eegFileRaw, '_emg.')
+                            modality = 'emg';
                         else
                             modality = 'eeg';
                         end


### PR DESCRIPTION
## Summary

Implements complete EMG-BIDS import and export functionality with support for multiple coordinate systems, nested coordinate systems, and multi-device recordings.

Closes #229

## Changes

### Import
- [x] EMG modality detection and folder structure support
- [x] Recording entity support for multi-device acquisitions
- [x] Multiple coordinate systems with space entities
- [x] BIDS inheritance for root-level coordsystem files
- [x] Nested coordinate systems with parent/child/anchor
- [x] Import coordinate_system field from electrodes.tsv
- [x] Set EEG.etc.datatype for export roundtrip

### Export
- [x] Correct modality folder placement (emg/ not eeg/)
- [x] Multiple coordsystem.json files with space entities
- [x] Parent coordinate system validation
- [x] Smart TSV column selection (only include columns with data)
- [x] Optional z coordinate for 2D electrode layouts
- [x] Warning messages for missing RECOMMENDED fields
- [x] EMG RECOMMENDED columns in channels.tsv and electrodes.tsv
- [x] Recording entity preservation

## Data Structure

```matlab
EEG.etc.datatype = 'emg'
EEG.recording = 'bipolar'  % for multi-device
EEG.chaninfo.BIDS.coordsystems = {
    struct('space', 'hand', 
           'EMGCoordinateSystem', 'Other',
           'EMGCoordinateUnits', 'percent', ...),
    struct('space', 'lowerLeg',
           'ParentCoordinateSystem', 'thigh',
           'AnchorElectrode', 'E6', ...)
}
EEG.chanlocs(i).coordinate_system = 'hand'
```

## Testing

Tested with all 7 EMG examples from bids-examples repository:
- [x] emg_CustomBipolar - Single coordsystem, basic bipolar
- [x] emg_CustomBipolarFace - Single coordsystem, face muscles
- [x] emg_MultiBodyParts - Multiple coordsystems (2): hand, lowerLeg
- [x] emg_ConcurrentIndependentUnits - Multiple datasets with nested coordsystems (4)
- [x] emg_IndependentMod - Independent monopolar
- [x] emg_TwoHDsEMG - HD-EMG grids with nested coordsystems (3)
- [x] emg_TwoWristbands - BIDS inheritance with root-level coordsystems (2)

All examples pass full roundtrip testing (import -> export -> validate structure).

## Files Modified

- pop_importbids.m - Add EMG support, recording entity, coordsystem discovery
- eeg_import.m - Check EEG.etc.datatype when loading .set files
- bids_importcoordsystemfile.m - Support multiple coordsystems with space entities
- bids_importchanlocs.m - Import coordinate_system field
- bids_writechanfile.m - Smart column selection, EMG RECOMMENDED columns
- bids_writeelectrodefile.m - Multiple coordsystems export, optional z, smart columns
- bids_getinfofromfolder.m - Scan for recording entities

## Backward Compatibility

- Single coordinate systems without space entities work as before
- EEG/iEEG/MEG modalities unaffected
- Existing datasets continue to import/export correctly

## Notes

- Coordinate system files are only exported when electrode locations exist
- Z coordinate is optional per BIDS spec (for 2D layouts)
- RECOMMENDED columns only included when data is available
- Parent coordinate system references validated before export